### PR TITLE
get env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,10 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+# .env.local
+# .env.development.local
+# .env.test.local
+# .env.production.local
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
temporarily commented out all .env* from gitignore for .env to showup 